### PR TITLE
Borrow the heck out of data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .idea/
+tests/fixtures/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.4.3"
 cxx = "1"
 flate2 = "1"
 log = "0.4"
-rdkit-sys = "0.3.0"
+rdkit-sys = "0.4.0"
 thiserror = "1"
 
 [dev-dependencies]

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -16,9 +16,9 @@ impl Properties {
     }
 
     pub fn compute_properties(&self, ro_mol: &ROMol) -> HashMap<String, f64> {
-        let names = rdkit_sys::descriptors_ffi::get_property_names(self.ptr.clone());
+        let names = rdkit_sys::descriptors_ffi::get_property_names(&self.ptr);
         let computed =
-            rdkit_sys::descriptors_ffi::compute_properties(self.ptr.clone(), ro_mol.ptr.clone());
+            rdkit_sys::descriptors_ffi::compute_properties(&self.ptr, &ro_mol.ptr);
 
         assert!(names.len() != 0);
         assert!(computed.len() == names.len());

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -6,7 +6,7 @@ pub struct Fingerprint(pub BitVec<u8, bitvec::order::Lsb0>);
 
 impl Fingerprint {
     pub fn new(ptr: SharedPtr<rdkit_sys::fingerprint_ffi::ExplicitBitVect>) -> Self {
-        let unique_ptr_bytes = rdkit_sys::fingerprint_ffi::explicit_bit_vect_to_u64_vec(ptr);
+        let unique_ptr_bytes = rdkit_sys::fingerprint_ffi::explicit_bit_vect_to_u64_vec(&ptr);
         let rdkit_fingerprint_bytes: Vec<u64> = unique_ptr_bytes.into_iter().map(|x| *x).collect();
         let mut bitvec_u64 = bitvec::vec::BitVec::<u64, Lsb0>::from_vec(rdkit_fingerprint_bytes);
 

--- a/src/graphmol/mol_ops.rs
+++ b/src/graphmol/mol_ops.rs
@@ -1,9 +1,21 @@
 use crate::ROMol;
+use rdkit_sys::ro_mol_ffi as ro_mol;
 
-pub fn detect_chemistry_problems(mol: &ROMol) -> Vec<String> {
-    let problems = rdkit_sys::ro_mol_ffi::detect_chemistry_problems(mol.ptr.clone());
+pub fn detect_chemistry_problems(mol: &ROMol) -> Vec<(String,Option<u32>)> {
+    let problems = rdkit_sys::ro_mol_ffi::detect_chemistry_problems(&mol.ptr);
     problems
         .iter()
-        .map(|p| p.to_string_lossy().to_string())
+        .map(|p| {
+            let type_ = ro_mol::mol_sanitize_exception_type(p);
+            match type_.as_str() {
+                "AtomValenceException" => {
+                    let atom_idx = ro_mol::atom_sanitize_exception_get_atom_idx(p);
+                    (type_, Some(atom_idx) )
+                },
+                _ => {
+                    (type_,None)
+                }
+            }
+        })
         .collect()
 }

--- a/src/graphmol/ro_mol.rs
+++ b/src/graphmol/ro_mol.rs
@@ -40,21 +40,21 @@ impl ROMol {
         params: &SmilesParserParams,
     ) -> Result<Self, cxx::Exception> {
         let_cxx_string!(smile_cxx_string = smile);
-        let ptr = ro_mol_ffi::smiles_to_mol_with_params(&smile_cxx_string, params.ptr.clone())?;
+        let ptr = ro_mol_ffi::smiles_to_mol_with_params(&smile_cxx_string, &params.ptr)?;
         Ok(Self { ptr })
     }
 
     pub fn as_smile(&self) -> String {
-        ro_mol_ffi::mol_to_smiles(self.ptr.clone())
+        ro_mol_ffi::mol_to_smiles(&self.ptr)
     }
 
     pub fn as_rw_mol(&self, quick_copy: bool, conf_id: i32) -> RWMol {
-        let ptr = rdkit_sys::rw_mol_ffi::rw_mol_from_ro_mol(self.ptr.clone(), quick_copy, conf_id);
+        let ptr = rdkit_sys::rw_mol_ffi::rw_mol_from_ro_mol(&self.ptr, quick_copy, conf_id);
         RWMol { ptr }
     }
 
     pub fn fingerprint(&self) -> Fingerprint {
-        let ptr = fingerprint_ffi::fingerprint_mol(self.ptr.clone());
+        let ptr = fingerprint_ffi::fingerprint_mol(&self.ptr);
         Fingerprint::new(ptr)
     }
 }
@@ -69,7 +69,7 @@ impl Debug for ROMol {
 impl Clone for ROMol {
     fn clone(&self) -> Self {
         ROMol {
-            ptr: rdkit_sys::ro_mol_ffi::copy_mol(self.ptr.clone()),
+            ptr: rdkit_sys::ro_mol_ffi::copy_mol(&self.ptr),
         }
     }
 }
@@ -80,7 +80,7 @@ pub struct SmilesParserParams {
 
 impl SmilesParserParams {
     pub fn sanitize(&mut self, value: bool) {
-        rdkit_sys::ro_mol_ffi::smiles_parser_params_set_sanitize(self.ptr.clone(), value);
+        rdkit_sys::ro_mol_ffi::smiles_parser_params_set_sanitize(&self.ptr, value);
     }
 }
 

--- a/src/graphmol/rw_mol.rs
+++ b/src/graphmol/rw_mol.rs
@@ -39,7 +39,7 @@ impl RWMol {
                 SharedPtr<rdkit_sys::ro_mol_ffi::ROMol>,
             >(self.ptr.clone())
         };
-        ro_mol_ffi::mol_to_smiles(cast_ptr)
+        ro_mol_ffi::mol_to_smiles(&cast_ptr)
     }
 
     pub fn to_ro_mol(self) -> ROMol {
@@ -55,7 +55,7 @@ impl RWMol {
 
 impl Clone for RWMol {
     fn clone(&self) -> Self {
-        let ptr = rw_mol_ffi::rw_mol_from_rw_mol(self.ptr.clone());
+        let ptr = rw_mol_ffi::rw_mol_from_rw_mol(&self.ptr);
         RWMol { ptr }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,6 @@ pub use mol_standardize::*;
 
 mod substruct_match;
 pub use substruct_match::*;
+
+mod verbose_file_parsers;
+pub use verbose_file_parsers::*;

--- a/src/mol_standardize.rs
+++ b/src/mol_standardize.rs
@@ -27,11 +27,11 @@ impl TautomerEnumerator {
 
     pub fn enumerate(&self, ro_mol: &crate::ROMol) -> TautomerEnumeratorResult {
         let t_enumerator_result = rdkit_sys::mol_standardize_ffi::tautomer_enumerate(
-            self.ptr.clone(),
-            ro_mol.ptr.clone(),
+            &self.ptr,
+            &ro_mol.ptr,
         );
         let size = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_size(
-            t_enumerator_result.clone(),
+            &t_enumerator_result,
         ) as usize;
 
         TautomerEnumeratorResult {
@@ -43,8 +43,8 @@ impl TautomerEnumerator {
 
     pub fn canonicalize(&self, ro_mol: &crate::ROMol) -> crate::ROMol {
         let canonical_mol_ptr = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_canonicalize(
-            self.ptr.clone(),
-            ro_mol.ptr.clone(),
+            &self.ptr,
+            &ro_mol.ptr,
         );
         crate::ROMol {
             ptr: canonical_mol_ptr,
@@ -68,7 +68,7 @@ impl Iterator for TautomerEnumeratorResult {
             None
         } else {
             let next = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_at(
-                self.t_enumerator_result.clone(),
+                &self.t_enumerator_result,
                 self.pos,
             );
             if next.is_null() {
@@ -86,7 +86,7 @@ impl Iterator for TautomerEnumeratorResult {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let size = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_size(
-            self.t_enumerator_result.clone(),
+            &self.t_enumerator_result,
         );
         (size as usize, Some(size as usize))
     }
@@ -98,8 +98,8 @@ pub fn fragment_parent(
     skip_standardize: bool,
 ) -> RWMol {
     let ptr = rdkit_sys::mol_standardize_ffi::fragment_parent(
-        rw_mol.ptr.clone(),
-        cleanup_params.ptr.clone(),
+        &rw_mol.ptr,
+        &cleanup_params.ptr,
         skip_standardize,
     );
     RWMol { ptr }
@@ -119,8 +119,8 @@ impl Uncharger {
     pub fn uncharge(&self, mol: &ROMol) -> ROMol {
         ROMol {
             ptr: rdkit_sys::mol_standardize_ffi::uncharger_uncharge(
-                self.ptr.clone(),
-                mol.ptr.clone(),
+                &self.ptr,
+                &mol.ptr,
             ),
         }
     }

--- a/src/substruct_match.rs
+++ b/src/substruct_match.rs
@@ -4,5 +4,5 @@ use crate::ROMol;
 
 pub fn substruct_match(mol: &ROMol, query: &ROMol) -> bool {
     let params = new_substruct_match_parameters();
-    substruct_match_as_bool(mol.ptr.clone(), query.ptr.clone(), params)
+    substruct_match_as_bool(&mol.ptr, &query.ptr, &params)
 }

--- a/tests/test_file_parsers.rs
+++ b/tests/test_file_parsers.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 #[test]
 fn test_mol_block() {
-    env_logger::init();
     let root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let root = PathBuf::from(root);
     let compounds_gz = root.join("tests/fixtures/Compound_000000001_000000010.sdf.gz");

--- a/tests/test_graphmol.rs
+++ b/tests/test_graphmol.rs
@@ -30,7 +30,6 @@ fn test_fragment_parent() {
 
 #[test]
 fn test_ro_mol_conversion_with_unknown_error() {
-    env_logger::init();
     let smiles = "string";
     let romol = ROMol::from_smile(smiles);
     assert_eq!(romol.err(), Some(ROMolError::UnknownConversionError))
@@ -38,7 +37,6 @@ fn test_ro_mol_conversion_with_unknown_error() {
 
 #[test]
 fn test_ro_mol_conversion_with_conversion_exception() {
-    env_logger::init();
     let smiles = "F(C)(C)(C)(C)(C)";
     let romol = ROMol::from_smile(smiles);
     assert_eq!(romol.err(), Some(ROMolError::ConversionException("Explicit valence for atom # 0 F, 5, is greater than permitted".to_string())))
@@ -261,10 +259,10 @@ fn test_detect_chemistry_problems() {
 
     let problems = detect_chemistry_problems(&mol);
     assert_eq!(
-        problems,
-        vec![
-            "AtomValenceException".to_string(),
-            "AtomValenceException".to_string()
+        &problems,
+        &[
+            ("AtomValenceException".to_string(), Some(1)),
+             ("AtomValenceException".to_string(), Some(11))
         ]
     );
 }


### PR DESCRIPTION
Pervasive and naive use of `clone()` throughout this code base. Things should be much more efficient now.