### PR TITLE
Correct all smiles occurances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RDKit
 ---
 
-A high-level library for performing common RDKit tasks such as SMILE parsing, molecule normalization, etc. Uses
+A high-level library for performing common RDKit tasks such as SMILES parsing, molecule normalization, etc. Uses
 the C++ API via bindings from [rdkit-sys](https://crates.io/crate/rdkit-sys).
 
 Prerequisites

--- a/benches/molecule_benchmark.rs
+++ b/benches/molecule_benchmark.rs
@@ -9,14 +9,14 @@ fn bench_molecules(bencher: &mut test::bench::Bencher) {
     let smiles1 = "c1ccccc1CCCCCCCC";
 
     bencher.iter(|| {
-        ROMol::from_smile(smiles1).unwrap();
+        ROMol::from_smiles(smiles1).unwrap();
     })
 }
 
 #[bench]
 fn bench_fingerprint(bencher: &mut test::bench::Bencher) {
     let smiles1 = "c1ccccc1CCCCCCCC";
-    let mol1 = ROMol::from_smile(smiles1).unwrap();
+    let mol1 = ROMol::from_smiles(smiles1).unwrap();
 
     bencher.iter(|| mol1.fingerprint())
 }
@@ -24,9 +24,9 @@ fn bench_fingerprint(bencher: &mut test::bench::Bencher) {
 #[bench]
 fn bench_tanimoto(bencher: &mut test::bench::Bencher) {
     let smiles1 = "c1ccccc1CCCCCCCC";
-    let mol1 = ROMol::from_smile(smiles1).unwrap();
+    let mol1 = ROMol::from_smiles(smiles1).unwrap();
     let smiles2 = "c1ccccc1CCCCCC";
-    let mol2 = ROMol::from_smile(smiles2).unwrap();
+    let mol2 = ROMol::from_smiles(smiles2).unwrap();
 
     bencher.iter(|| {
         let mol1_fingerprint = mol1.fingerprint();

--- a/examples/tautomer_enumerator.rs
+++ b/examples/tautomer_enumerator.rs
@@ -1,14 +1,14 @@
 use rdkit::{ROMol, TautomerEnumerator};
 
 fn main() {
-    let mol = ROMol::from_smile("c1ccccc1C(=O)NC").unwrap();
+    let mol = ROMol::from_smiles("c1ccccc1C(=O)NC").unwrap();
     let enumerator = TautomerEnumerator::new();
     let enumerator_result = enumerator.enumerate(&mol);
 
     for t in enumerator_result {
-        println!("{}", t.as_smile());
+        println!("{}", t.as_smiles());
     }
 
     let canonical_mol = enumerator.canonicalize(&mol);
-    println!("{}", canonical_mol.as_smile());
+    println!("{}", canonical_mol.as_smiles());
 }

--- a/rdkit-sys/examples/tautomer_enumerator.rs
+++ b/rdkit-sys/examples/tautomer_enumerator.rs
@@ -1,8 +1,8 @@
 use cxx::let_cxx_string;
 
 fn main() {
-    let_cxx_string!(smile = "c1ccccc1C(=O)NC");
-    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    let_cxx_string!(smiles = "c1ccccc1C(=O)NC");
+    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
     let tautomer_enumerator = rdkit_sys::mol_standardize_ffi::tautomer_enumerator();
     let tautomer_enumerator_result =
         rdkit_sys::mol_standardize_ffi::tautomer_enumerate(&tautomer_enumerator, &mol);
@@ -15,20 +15,20 @@ fn main() {
         &tautomer_enumerator_result,
         0,
     );
-    let first_smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first);
-    println!("first smile: {}", first_smile);
+    let first_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first);
+    println!("first smiles: {}", first_smiles);
 
     let second = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_at(
         &tautomer_enumerator_result,
         1,
     );
-    let second_smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second);
-    println!("second smile: {}", second_smile);
+    let second_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second);
+    println!("second smiles: {}", second_smiles);
 
     let canonical_mol = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_canonicalize(
         &tautomer_enumerator,
         &mol,
     );
-    let canonical_smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&canonical_mol);
-    println!("canonical: {}", canonical_smile);
+    let canonical_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&canonical_mol);
+    println!("canonical: {}", canonical_smiles);
 }

--- a/rdkit-sys/src/lib.rs
+++ b/rdkit-sys/src/lib.rs
@@ -9,7 +9,7 @@
 //! It is highly recommend you read through the [RDKit C++ API documentation](https://www.rdkit.org/docs/cppapi/index.html) to learn more
 //! about what exactly is possible with RDKit.
 //!
-//! If you just want high level access to SMILE parsing and various clean up
+//! If you just want high level access to SMILES parsing and various clean up
 //! operations, please refer to the high level accompanying crate [rdkit](https://www.crates.io/crate/rdkit).
 
 mod bridge;

--- a/rdkit-sys/tests/test_atoms.rs
+++ b/rdkit-sys/tests/test_atoms.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_atoms() {
-    cxx::let_cxx_string!(smile = "c1ccccc1CCCCCCCC");
-    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "c1ccccc1CCCCCCCC");
+    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
 
     let num_atoms = rdkit_sys::ro_mol_ffi::get_num_atoms(&romol, true);
 

--- a/rdkit-sys/tests/test_descriptors.rs
+++ b/rdkit-sys/tests/test_descriptors.rs
@@ -2,8 +2,8 @@ use cxx::let_cxx_string;
 
 #[test]
 fn test_descriptors() {
-    let_cxx_string!(smile = "c1ccccc1C(=O)NC");
-    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    let_cxx_string!(smiles = "c1ccccc1C(=O)NC");
+    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
 
     let properties = rdkit_sys::descriptors_ffi::new_properties();
 

--- a/rdkit-sys/tests/test_fingerprint.rs
+++ b/rdkit-sys/tests/test_fingerprint.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_fingerprint_to_vec() {
-    cxx::let_cxx_string!(smile = "c1ccccc1CCCCCCCC");
-    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "c1ccccc1CCCCCCCC");
+    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
 
     let fingerprint = rdkit_sys::fingerprint_ffi::fingerprint_mol(&mol);
     let bytes = rdkit_sys::fingerprint_ffi::explicit_bit_vect_to_u64_vec(&fingerprint);

--- a/rdkit-sys/tests/test_mol_ops.rs
+++ b/rdkit-sys/tests/test_mol_ops.rs
@@ -2,23 +2,23 @@ use rdkit_sys::mol_ops_ffi::*;
 
 #[test]
 fn test_mol_ops_substruct_match_as_bool() {
-    cxx::let_cxx_string!(smile = "c1ccccc1CCCCCCCC");
-    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "c1ccccc1CCCCCCCC");
+    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
 
     let params = new_remove_hs_parameters();
 
     let mut new_mol = remove_hs_parameters(&mol, &params, true);
-    let new_smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&new_mol);
+    let new_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&new_mol);
 
     romol_set_hybridization(&mut new_mol);
 
-    assert_eq!(new_smile, "CCCCCCCCc1ccccc1");
+    assert_eq!(new_smiles, "CCCCCCCCc1ccccc1");
 }
 
 #[test]
 fn test_mol_ops_cleanup() {
-    cxx::let_cxx_string!(smile = "[H]C([H])([H])([H])");
-    let ro_mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "[H]C([H])([H])([H])");
+    let ro_mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
     let mut rw_mol = rdkit_sys::rw_mol_ffi::rw_mol_from_ro_mol(&ro_mol, true, 0);
     clean_up(&mut rw_mol);
     let new_ro_mol = rdkit_sys::rw_mol_ffi::rw_mol_to_ro_mol(rw_mol); // low-cost pointer swap

--- a/rdkit-sys/tests/test_mol_standardize.rs
+++ b/rdkit-sys/tests/test_mol_standardize.rs
@@ -2,8 +2,8 @@ use cxx::let_cxx_string;
 
 #[test]
 fn test_tautomer_enumerator() {
-    let_cxx_string!(smile = "c1ccccc1C(=O)NC");
-    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    let_cxx_string!(smiles = "c1ccccc1C(=O)NC");
+    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
     let tautomer_enumerator = rdkit_sys::mol_standardize_ffi::tautomer_enumerator();
     let tautomer_enumerator_result =
         rdkit_sys::mol_standardize_ffi::tautomer_enumerate(&tautomer_enumerator, &mol);
@@ -16,13 +16,13 @@ fn test_tautomer_enumerator() {
         &tautomer_enumerator_result,
         0,
     );
-    let first_smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first);
-    assert_eq!("CN=C(O)c1ccccc1", first_smile);
+    let first_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first);
+    assert_eq!("CN=C(O)c1ccccc1", first_smiles);
 
     let second = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_at(
         &tautomer_enumerator_result,
         1,
     );
-    let second_smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second);
-    assert_eq!("CNC(=O)c1ccccc1", second_smile);
+    let second_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second);
+    assert_eq!("CNC(=O)c1ccccc1", second_smiles);
 }

--- a/rdkit-sys/tests/test_ro_mol.rs
+++ b/rdkit-sys/tests/test_ro_mol.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_ro_mol() {
-    cxx::let_cxx_string!(smile = "c1ccccc1CCCCCCCC");
-    let mut romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "c1ccccc1CCCCCCCC");
+    let mut romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
     assert!(!romol.is_null());
 
     rdkit_sys::ro_mol_ffi::ro_mol_update_property_cache(&mut romol, true);
@@ -9,8 +9,8 @@ fn test_ro_mol() {
 
 #[test]
 fn bad_mol_test() {
-    cxx::let_cxx_string!(smile = "F(C)(C)(C)(C)(C)");
-    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile);
+    cxx::let_cxx_string!(smiles = "F(C)(C)(C)(C)(C)");
+    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles);
 
     if let Err(e) = romol {
         assert_eq!(
@@ -24,17 +24,17 @@ fn bad_mol_test() {
 
 #[test]
 fn parse_without_sanitize_test() {
-    cxx::let_cxx_string!(smile = "N#[N]c1ccc(cc1)N(C)CN(C)(C)(C)");
+    cxx::let_cxx_string!(smiles = "N#[N]c1ccc(cc1)N(C)CN(C)(C)(C)");
 
     let params = rdkit_sys::ro_mol_ffi::new_smiles_parser_params();
 
     rdkit_sys::ro_mol_ffi::smiles_parser_params_set_sanitize(&params, true);
-    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol_with_params(&smile, &params);
+    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol_with_params(&smiles, &params);
 
     assert!(romol.is_err());
 
     rdkit_sys::ro_mol_ffi::smiles_parser_params_set_sanitize(&params, false);
-    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol_with_params(&smile, &params);
+    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol_with_params(&smiles, &params);
 
     assert!(romol.is_ok());
 

--- a/rdkit-sys/tests/test_rw_mol.rs
+++ b/rdkit-sys/tests/test_rw_mol.rs
@@ -7,8 +7,8 @@ fn test_rw_mol_from_smarts() {
     let rwmol = rdkit_sys::rw_mol_ffi::smarts_to_mol(&smarts).unwrap();
     let romol = rdkit_sys::rw_mol_ffi::rw_mol_to_ro_mol(rwmol);
 
-    let smile = rdkit_sys::ro_mol_ffi::mol_to_smiles(&romol);
-    assert_eq!(smile, "*".to_string());
+    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&romol);
+    assert_eq!(smiles, "*".to_string());
 }
 
 #[test]

--- a/rdkit-sys/tests/test_substruct_match.rs
+++ b/rdkit-sys/tests/test_substruct_match.rs
@@ -2,11 +2,11 @@ use rdkit_sys::substruct_match_ffi::*;
 
 #[test]
 fn test_substruct_match_as_bool() {
-    cxx::let_cxx_string!(smile = "c1ccccc1CCCCCCCC");
-    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "c1ccccc1CCCCCCCC");
+    let mol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
 
-    cxx::let_cxx_string!(smile = "C");
-    let query = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smile).unwrap();
+    cxx::let_cxx_string!(smiles = "C");
+    let query = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
 
     let match_params = new_substruct_match_parameters();
 

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -33,10 +33,10 @@ mod tests {
 
     #[test]
     fn make_sure_fingerprint_works() {
-        let mol = ROMol::from_smile("CCC=O").unwrap();
+        let mol = ROMol::from_smiles("CCC=O").unwrap();
         let fingerprint = mol.fingerprint();
 
-        let mol_two = ROMol::from_smile("CCC=N").unwrap();
+        let mol_two = ROMol::from_smiles("CCC=N").unwrap();
         let fingerprint_two = mol_two.fingerprint();
 
         let distance = fingerprint.tanimoto_distance(&fingerprint_two);

--- a/src/graphmol/ro_mol.rs
+++ b/src/graphmol/ro_mol.rs
@@ -11,16 +11,16 @@ pub struct ROMol {
 
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum ROMolError {
-    #[error("could not convert smile to romol (nullptr)")]
+    #[error("could not convert smiles to romol (nullptr)")]
     UnknownConversionError,
-    #[error("could not convert smile to romol (exception)")]
+    #[error("could not convert smiles to romol (exception)")]
     ConversionException(String),
 }
 
 impl ROMol {
-    pub fn from_smile(smile: &str) -> Result<Self, ROMolError> {
-        let_cxx_string!(smile_cxx_string = smile);
-        let ptr = ro_mol_ffi::smiles_to_mol(&smile_cxx_string);
+    pub fn from_smiles(smiles: &str) -> Result<Self, ROMolError> {
+        let_cxx_string!(smiles_cxx_string = smiles);
+        let ptr = ro_mol_ffi::smiles_to_mol(&smiles_cxx_string);
         match ptr {
             Ok(ptr) => {
                 if ptr.is_null() {
@@ -33,16 +33,16 @@ impl ROMol {
         }
     }
 
-    pub fn from_smile_with_params(
-        smile: &str,
+    pub fn from_smiles_with_params(
+        smiles: &str,
         params: &SmilesParserParams,
     ) -> Result<Self, cxx::Exception> {
-        let_cxx_string!(smile_cxx_string = smile);
-        let ptr = ro_mol_ffi::smiles_to_mol_with_params(&smile_cxx_string, &params.ptr)?;
+        let_cxx_string!(smiles_cxx_string = smiles);
+        let ptr = ro_mol_ffi::smiles_to_mol_with_params(&smiles_cxx_string, &params.ptr)?;
         Ok(Self { ptr })
     }
 
-    pub fn as_smile(&self) -> String {
+    pub fn as_smiles(&self) -> String {
         ro_mol_ffi::mol_to_smiles(&self.ptr)
     }
 
@@ -76,8 +76,8 @@ impl ROMol {
 
 impl Debug for ROMol {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let smile = self.as_smile();
-        f.debug_tuple("ROMol").field(&smile).finish()
+        let smiles = self.as_smiles();
+        f.debug_tuple("ROMol").field(&smiles).finish()
     }
 }
 

--- a/src/graphmol/rw_mol.rs
+++ b/src/graphmol/rw_mol.rs
@@ -28,7 +28,7 @@ impl RWMol {
         }
     }
 
-    pub fn as_smile(&self) -> String {
+    pub fn as_smiles(&self) -> String {
         let cast_ptr = unsafe {
             std::mem::transmute::<
                 SharedPtr<rdkit_sys::rw_mol_ffi::RWMol>,
@@ -65,7 +65,7 @@ impl Clone for RWMol {
 
 impl std::fmt::Debug for RWMol {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let smile = self.as_smile();
-        f.debug_tuple("RWMol").field(&smile).finish()
+        let smiles = self.as_smiles();
+        f.debug_tuple("RWMol").field(&smiles).finish()
     }
 }

--- a/tests/test_atom.rs
+++ b/tests/test_atom.rs
@@ -1,6 +1,6 @@
 #[test]
 fn test_atom() {
-    let romol = rdkit::ROMol::from_smile("C").unwrap();
+    let romol = rdkit::ROMol::from_smiles("C").unwrap();
 
     let atom_iter = romol.atoms(true);
     let atoms = atom_iter.collect::<Vec<_>>();

--- a/tests/test_descriptors.rs
+++ b/tests/test_descriptors.rs
@@ -4,7 +4,7 @@ use rdkit::{Properties, ROMol};
 
 #[test]
 fn test_a_thing() {
-    let mol = ROMol::from_smile("c1ccccc1C(=O)NC").unwrap();
+    let mol = ROMol::from_smiles("c1ccccc1C(=O)NC").unwrap();
     let properties = Properties::new();
     let computed: HashMap<String, f64> = properties.compute_properties(&mol);
     assert_eq!(*computed.get("NumAtoms").unwrap(), 19.0);
@@ -13,7 +13,7 @@ fn test_a_thing() {
 #[test]
 fn test_computing_properties() {
     let smiles = "CCOC(=O)C(C)(C)OC1=CC=C(C=C1)Cl.CO.C1=CC(=CC=C1C(=O)N[C@@H](CCC(=O)O)C(=O)O)NCC2=CN=C3C(=N2)C(=O)NC(=N3)N";
-    let romol = ROMol::from_smile(smiles).unwrap();
+    let romol = ROMol::from_smiles(smiles).unwrap();
 
     let properties = Properties::new();
 

--- a/tests/test_fingerprint.rs
+++ b/tests/test_fingerprint.rs
@@ -3,8 +3,8 @@ use rdkit::ROMol;
 
 #[test]
 fn test_fingerprint() {
-    let smile = "c1ccccc1CCCCCCCC";
-    let mol = ROMol::from_smile(smile).unwrap();
+    let smiles = "c1ccccc1CCCCCCCC";
+    let mol = ROMol::from_smiles(smiles).unwrap();
     let fingerprint = mol.fingerprint();
     let expected = bitvec![
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/tests/test_graphmol.rs
+++ b/tests/test_graphmol.rs
@@ -6,43 +6,43 @@ use rdkit::{
 
 #[test]
 fn test_rdmol() {
-    let _ = ROMol::from_smile("c1ccccc1C(=O)NC").unwrap();
+    let _ = ROMol::from_smiles("c1ccccc1C(=O)NC").unwrap();
 }
 
 #[test]
 fn test_neutralize() {
     let smiles = "CCOC(=O)C(C)(C)OC1=CC=C(C=C1)Cl.CO.C1=CC(=CC=C1C(=O)N[C@@H](CCC(=O)O)C(=O)O)NCC2=CN=C3C(=N2)C(=O)NC(=N3)N";
-    let romol = ROMol::from_smile(smiles).unwrap();
+    let romol = ROMol::from_smiles(smiles).unwrap();
     let uncharger = Uncharger::new(false);
     let uncharged_mol = uncharger.uncharge(&romol);
-    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", uncharged_mol.as_smile());
+    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", uncharged_mol.as_smiles());
 }
 
 #[test]
 fn test_fragment_parent() {
     let smiles = "CCOC(=O)C(C)(C)OC1=CC=C(C=C1)Cl.CO.C1=CC(=CC=C1C(=O)N[C@@H](CCC(=O)O)C(=O)O)NCC2=CN=C3C(=N2)C(=O)NC(=N3)N";
-    let romol = ROMol::from_smile(smiles).unwrap();
+    let romol = ROMol::from_smiles(smiles).unwrap();
     let rwmol = romol.as_rw_mol(false, 1);
     let cleanup_params = CleanupParameters::default();
     let parent_rwmol = fragment_parent(&rwmol, &cleanup_params, true);
     assert_eq!(
         "Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1",
-        parent_rwmol.as_smile()
+        parent_rwmol.as_smiles()
     );
-    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", rwmol.as_smile());
+    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", rwmol.as_smiles());
 }
 
 #[test]
 fn test_ro_mol_conversion_with_unknown_error() {
     let smiles = "string";
-    let romol = ROMol::from_smile(smiles);
+    let romol = ROMol::from_smiles(smiles);
     assert_eq!(romol.err(), Some(ROMolError::UnknownConversionError))
 }
 
 #[test]
 fn test_ro_mol_conversion_with_conversion_exception() {
     let smiles = "F(C)(C)(C)(C)(C)";
-    let romol = ROMol::from_smile(smiles);
+    let romol = ROMol::from_smiles(smiles);
     assert_eq!(
         romol.err(),
         Some(ROMolError::ConversionException(
@@ -54,7 +54,7 @@ fn test_ro_mol_conversion_with_conversion_exception() {
 #[test]
 fn test_enumerate_tautomer() {
     let smiles = "Oc1c(cccc3)c3nc2ccncc12";
-    let romol = ROMol::from_smile(smiles).unwrap();
+    let romol = ROMol::from_smiles(smiles).unwrap();
     let te = TautomerEnumerator::new();
     let ter = te.enumerate(&romol);
     let ts = ter.collect::<Vec<_>>();
@@ -64,7 +64,7 @@ fn test_enumerate_tautomer() {
 #[test]
 fn test_stdz() {
     let smiles = "CC.Oc1c(cccc3CC(C(=O)[O-]))c3nc2c(C[NH+])cncc12.[Cl-]";
-    let romol = ROMol::from_smile(smiles).unwrap();
+    let romol = ROMol::from_smiles(smiles).unwrap();
     let rwmol = romol.as_rw_mol(false, 1);
 
     let cleanup_params = CleanupParameters::default();
@@ -77,7 +77,7 @@ fn test_stdz() {
     let canon_taut = te.canonicalize(&uncharged_mol);
     assert_eq!(
         "[N]Cc1cncc2c(=O)c3cccc(CCC(=O)O)c3[nH]c12",
-        canon_taut.as_smile()
+        canon_taut.as_smiles()
     );
 }
 
@@ -256,7 +256,7 @@ CC(=O)OC(CC(=O)[O-])C[N+](C)(C)C
 "#;
 
     let rw_mol = RWMol::from_mol_block(mol_block, false, false, false).unwrap();
-    assert_eq!("[H]C([H])([H])C(=O)OC([H])(C([H])([H])C(=O)[O-])C([H])([H])[N+](C([H])([H])[H])(C([H])([H])[H])C([H])([H])[H]", &rw_mol.as_smile());
+    assert_eq!("[H]C([H])([H])C(=O)OC([H])(C([H])([H])C(=O)[O-])C([H])([H])[N+](C([H])([H])[H])(C([H])([H])[H])C([H])([H])[H]", &rw_mol.as_smiles());
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn test_detect_chemistry_problems() {
     let smile = "N#[N]c1ccc(cc1)N(C)CN(C)(C)(C)";
     let mut parser_params = SmilesParserParams::default();
     parser_params.sanitize(false);
-    let mol = ROMol::from_smile_with_params(smile, &parser_params).unwrap();
+    let mol = ROMol::from_smiles_with_params(smile, &parser_params).unwrap();
 
     let problems = detect_chemistry_problems(&mol);
     assert_eq!(
@@ -286,7 +286,7 @@ fn test_detect_chemistry_problems() {
 fn test_building_rwmol_from_smarts() {
     let smarts = "[+1!h0!$([*]~[-1,-2,-3,-4]),-1!$([*]~[+1,+2,+3,+4])]";
 
-    let ro_mol = ROMol::from_smile("C[N+](C)(C)C").unwrap();
+    let ro_mol = ROMol::from_smiles("C[N+](C)(C)C").unwrap();
 
     let rwmol = RWMol::from_smarts(smarts).unwrap();
     let query_mol = rwmol.to_ro_mol();

--- a/tests/test_mol_ops.rs
+++ b/tests/test_mol_ops.rs
@@ -18,23 +18,23 @@ use rdkit::{add_hs, clean_up, remove_hs, set_hybridization, ROMol, RemoveHsParam
 
 #[test]
 fn test_remove_hs() {
-    let ro_mol = ROMol::from_smile("[2H]C").unwrap();
+    let ro_mol = ROMol::from_smiles("[2H]C").unwrap();
 
     let mut remove_hs_parameters = RemoveHsParameters::new();
     remove_hs_parameters.set_remove_and_track_isotopes(true);
     remove_hs_parameters.set_remove_defining_bond_stereo(true);
 
     let new_mol = remove_hs(&ro_mol, &remove_hs_parameters, true);
-    let new_smile = new_mol.as_smile();
+    let new_smile = new_mol.as_smiles();
     assert_eq!(new_smile, "C");
 
     let new_new_mol = add_hs(&new_mol, true, true, true);
-    let new_new_smile = new_new_mol.as_smile();
+    let new_new_smile = new_new_mol.as_smiles();
     assert_eq!(new_new_smile, "C");
 
     let remove_hs_parameters = RemoveHsParameters::new();
     let mut new_new_new_mol = remove_hs(&new_new_mol, &remove_hs_parameters, true);
-    let new_new_new_smile = new_new_new_mol.as_smile();
+    let new_new_new_smile = new_new_new_mol.as_smiles();
 
     set_hybridization(&mut new_new_new_mol);
 
@@ -43,10 +43,10 @@ fn test_remove_hs() {
 
 #[test]
 fn test_mol_ops_clean_up() {
-    let ro_mol = ROMol::from_smile("[H]C([H])([H])([H])").unwrap();
+    let ro_mol = ROMol::from_smiles("[H]C([H])([H])([H])").unwrap();
     let mut rw_mol = ro_mol.as_rw_mol(true, 0);
     clean_up(&mut rw_mol);
     let new_ro_mol = rw_mol.to_ro_mol();
-    let smiles = new_ro_mol.as_smile();
+    let smiles = new_ro_mol.as_smiles();
     assert_eq!(smiles, "C");
 }

--- a/tests/test_substruct.rs
+++ b/tests/test_substruct.rs
@@ -2,8 +2,8 @@ use rdkit::{substruct_match, ROMol, SubstructMatchParameters};
 
 #[test]
 fn test_substruct_match() {
-    let mol = ROMol::from_smile("c1ccccc1CCCCCCCC").unwrap();
-    let query = ROMol::from_smile("C").unwrap();
+    let mol = ROMol::from_smiles("c1ccccc1CCCCCCCC").unwrap();
+    let query = ROMol::from_smiles("C").unwrap();
     let params = SubstructMatchParameters::new();
 
     let does_it_match = substruct_match(&mol, &query, &params);


### PR DESCRIPTION
This ensure that "smiles" is always represented in the pluralized form (i.e. not "smile"). Note: this will affect methods being used in `cheminee`, so updates will need to be made there.