### PR TITLE
Catch RDKit exceptions when converting Mol->SMILES / falible `mol_to_smiles`

### DIFF
--- a/examples/tautomer_enumerator.rs
+++ b/examples/tautomer_enumerator.rs
@@ -6,9 +6,9 @@ fn main() {
     let enumerator_result = enumerator.enumerate(&mol);
 
     for t in enumerator_result {
-        println!("{}", t.as_smiles());
+        println!("{}", t.as_smiles().unwrap());
     }
 
     let canonical_mol = enumerator.canonicalize(&mol);
-    println!("{}", canonical_mol.as_smiles());
+    println!("{}", canonical_mol.as_smiles().unwrap());
 }

--- a/rdkit-sys/examples/rdkit_sys_tautomer_enumerator.rs
+++ b/rdkit-sys/examples/rdkit_sys_tautomer_enumerator.rs
@@ -15,20 +15,20 @@ fn main() {
         &tautomer_enumerator_result,
         0,
     );
-    let first_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first);
+    let first_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first).unwrap();
     println!("first smiles: {}", first_smiles);
 
     let second = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_at(
         &tautomer_enumerator_result,
         1,
     );
-    let second_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second);
+    let second_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second).unwrap();
     println!("second smiles: {}", second_smiles);
 
     let canonical_mol = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_canonicalize(
         &tautomer_enumerator,
         &mol,
     );
-    let canonical_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&canonical_mol);
+    let canonical_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&canonical_mol).unwrap();
     println!("canonical: {}", canonical_smiles);
 }

--- a/rdkit-sys/src/bridge/ro_mol.rs
+++ b/rdkit-sys/src/bridge/ro_mol.rs
@@ -40,7 +40,7 @@ pub mod ffi {
             sanitize: bool,
         );
 
-        pub fn mol_to_smiles(mol: &SharedPtr<ROMol>) -> String;
+        pub fn mol_to_smiles(mol: &SharedPtr<ROMol>) -> Result<String>;
 
         pub fn detect_chemistry_problems(
             mol: &SharedPtr<ROMol>,

--- a/rdkit-sys/tests/test_mol_ops.rs
+++ b/rdkit-sys/tests/test_mol_ops.rs
@@ -8,7 +8,7 @@ fn test_mol_ops_substruct_match_as_bool() {
     let params = new_remove_hs_parameters();
 
     let mut new_mol = remove_hs_parameters(&mol, &params, true);
-    let new_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&new_mol);
+    let new_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&new_mol).unwrap();
 
     romol_set_hybridization(&mut new_mol);
 
@@ -22,6 +22,6 @@ fn test_mol_ops_cleanup() {
     let mut rw_mol = rdkit_sys::rw_mol_ffi::rw_mol_from_ro_mol(&ro_mol, true, 0);
     clean_up(&mut rw_mol);
     let new_ro_mol = rdkit_sys::rw_mol_ffi::rw_mol_to_ro_mol(rw_mol); // low-cost pointer swap
-    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&new_ro_mol);
+    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&new_ro_mol).unwrap();
     assert_eq!(smiles, "C");
 }

--- a/rdkit-sys/tests/test_mol_standardize.rs
+++ b/rdkit-sys/tests/test_mol_standardize.rs
@@ -16,13 +16,13 @@ fn test_tautomer_enumerator() {
         &tautomer_enumerator_result,
         0,
     );
-    let first_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first);
+    let first_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&first).unwrap();
     assert_eq!("CN=C(O)c1ccccc1", first_smiles);
 
     let second = rdkit_sys::mol_standardize_ffi::tautomer_enumerator_result_tautomers_at(
         &tautomer_enumerator_result,
         1,
     );
-    let second_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second);
+    let second_smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&second).unwrap();
     assert_eq!("CNC(=O)c1ccccc1", second_smiles);
 }

--- a/rdkit-sys/tests/test_ro_mol.rs
+++ b/rdkit-sys/tests/test_ro_mol.rs
@@ -1,3 +1,5 @@
+use rdkit_sys::ro_mol_ffi::mol_to_smiles;
+
 #[test]
 fn test_ro_mol() {
     cxx::let_cxx_string!(smiles = "c1ccccc1CCCCCCCC");
@@ -62,4 +64,14 @@ fn parse_without_sanitize_test() {
         })
         .collect::<Vec<_>>();
     assert_eq!(atoms, &["N", "N"]);
+}
+
+#[test]
+fn mol_to_smiles_failure_test() {
+    // This failing case was replicated on:
+    // - python 3.11.5, version 2022.09.1
+    // - debian bookworm, librdkit-dev 202209.3-1
+    cxx::let_cxx_string!(smiles = r"CCOC(=O)/C=S(/c1ccc(C(F)(F)F)cc1)=C1/C=C(\C)CCC1=O");
+    let romol = rdkit_sys::ro_mol_ffi::smiles_to_mol(&smiles).unwrap();
+    assert!(mol_to_smiles(&romol).is_err())
 }

--- a/rdkit-sys/tests/test_rw_mol.rs
+++ b/rdkit-sys/tests/test_rw_mol.rs
@@ -7,7 +7,7 @@ fn test_rw_mol_from_smarts() {
     let rwmol = rdkit_sys::rw_mol_ffi::smarts_to_mol(&smarts).unwrap();
     let romol = rdkit_sys::rw_mol_ffi::rw_mol_to_ro_mol(rwmol);
 
-    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&romol);
+    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&romol).unwrap();
     assert_eq!(smiles, "*".to_string());
 }
 
@@ -190,7 +190,7 @@ CC(=O)OC(CC(=O)[O-])C[N+](C)(C)C
     let rw_mol = rdkit_sys::rw_mol_ffi::rw_mol_from_mol_block(&mol_block, false, false, false);
     let ro_mol = unsafe { std::mem::transmute::<SharedPtr<RWMol>, SharedPtr<ROMol>>(rw_mol) };
 
-    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&ro_mol);
+    let smiles = rdkit_sys::ro_mol_ffi::mol_to_smiles(&ro_mol).unwrap();
     assert_eq!("[H]C([H])([H])C(=O)OC([H])(C([H])([H])C(=O)[O-])C([H])([H])[N+](C([H])([H])[H])(C([H])([H])[H])C([H])([H])[H]", &smiles);
 }
 

--- a/src/graphmol/ro_mol.rs
+++ b/src/graphmol/ro_mol.rs
@@ -42,7 +42,7 @@ impl ROMol {
         Ok(Self { ptr })
     }
 
-    pub fn as_smiles(&self) -> String {
+    pub fn as_smiles(&self) -> Result<String, cxx::Exception> {
         ro_mol_ffi::mol_to_smiles(&self.ptr)
     }
 

--- a/src/graphmol/rw_mol.rs
+++ b/src/graphmol/rw_mol.rs
@@ -28,7 +28,7 @@ impl RWMol {
         }
     }
 
-    pub fn as_smiles(&self) -> String {
+    pub fn as_smiles(&self) -> Result<String, cxx::Exception> {
         let cast_ptr = unsafe {
             std::mem::transmute::<
                 SharedPtr<rdkit_sys::rw_mol_ffi::RWMol>,

--- a/tests/test_graphmol.rs
+++ b/tests/test_graphmol.rs
@@ -15,7 +15,7 @@ fn test_neutralize() {
     let romol = ROMol::from_smiles(smiles).unwrap();
     let uncharger = Uncharger::new(false);
     let uncharged_mol = uncharger.uncharge(&romol);
-    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", uncharged_mol.as_smiles());
+    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", uncharged_mol.as_smiles().unwrap());
 }
 
 #[test]
@@ -27,9 +27,9 @@ fn test_fragment_parent() {
     let parent_rwmol = fragment_parent(&rwmol, &cleanup_params, true);
     assert_eq!(
         "Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1",
-        parent_rwmol.as_smiles()
+        parent_rwmol.as_smiles().unwrap()
     );
-    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", rwmol.as_smiles());
+    assert_eq!("CCOC(=O)C(C)(C)Oc1ccc(Cl)cc1.CO.Nc1nc2ncc(CNc3ccc(C(=O)N[C@@H](CCC(=O)O)C(=O)O)cc3)nc2c(=O)[nH]1", rwmol.as_smiles().unwrap());
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn test_stdz() {
     let canon_taut = te.canonicalize(&uncharged_mol);
     assert_eq!(
         "[N]Cc1cncc2c(=O)c3cccc(CCC(=O)O)c3[nH]c12",
-        canon_taut.as_smiles()
+        canon_taut.as_smiles().unwrap()
     );
 }
 
@@ -256,7 +256,7 @@ CC(=O)OC(CC(=O)[O-])C[N+](C)(C)C
 "#;
 
     let rw_mol = RWMol::from_mol_block(mol_block, false, false, false).unwrap();
-    assert_eq!("[H]C([H])([H])C(=O)OC([H])(C([H])([H])C(=O)[O-])C([H])([H])[N+](C([H])([H])[H])(C([H])([H])[H])C([H])([H])[H]", &rw_mol.as_smiles());
+    assert_eq!("[H]C([H])([H])C(=O)OC([H])(C([H])([H])C(=O)[O-])C([H])([H])[N+](C([H])([H])[H])(C([H])([H])[H])C([H])([H])[H]", &rw_mol.as_smiles().unwrap());
 }
 
 #[test]

--- a/tests/test_mol_ops.rs
+++ b/tests/test_mol_ops.rs
@@ -25,16 +25,16 @@ fn test_remove_hs() {
     remove_hs_parameters.set_remove_defining_bond_stereo(true);
 
     let no_hs_mol = remove_hs(&ro_mol, &remove_hs_parameters, true);
-    let no_hs_smiles = no_hs_mol.as_smiles();
+    let no_hs_smiles = no_hs_mol.as_smiles().unwrap();
     assert_eq!(no_hs_smiles, "C");
 
     let add_hs_mol = add_hs(&no_hs_mol, false, false, false);
-    let add_hs_smiles = add_hs_mol.as_smiles();
+    let add_hs_smiles = add_hs_mol.as_smiles().unwrap();
     assert_eq!(add_hs_smiles, "[H]C([H])([H])[2H]");
 
     let remove_hs_parameters = RemoveHsParameters::new();
     let mut no_hs_mol2 = remove_hs(&add_hs_mol, &remove_hs_parameters, true);
-    let no_hs_smiles2 = no_hs_mol2.as_smiles();
+    let no_hs_smiles2 = no_hs_mol2.as_smiles().unwrap();
     set_hybridization(&mut no_hs_mol2);
     assert_eq!(no_hs_smiles2, "[2H]C");
 }
@@ -45,6 +45,6 @@ fn test_mol_ops_clean_up() {
     let mut rw_mol = ro_mol.as_rw_mol(true, 0);
     clean_up(&mut rw_mol);
     let new_ro_mol = rw_mol.to_ro_mol();
-    let smiles = new_ro_mol.as_smiles();
+    let smiles = new_ro_mol.as_smiles().unwrap();
     assert_eq!(smiles, "C");
 }


### PR DESCRIPTION
Summary of changes / checks:
 - Updated RDKit sys and RDKit rs so that `mol_to_smiles` and `romol.as_smiles` return a result
 - Added new test in rdkit sys capturing a negative example i.e. mol_to_smiles returning an err
 - Updated examples and tests where mol_to_smiles and as_smiles are used, call unwrap on results
 - Run cargo fmt
 
Noted that the tests for descriptors in both rdkit-sys and rdkit were not working on my local machine using conda RDKit (2022.09.1) before or after my changes. Otherwise, all tests are passing.   