### PR TITLE
Bump rdkit and rdkit-sys versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkit"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 authors = ["Xavier Lange <xrlange@gmail.com>"]
 license = "MIT"

--- a/rdkit-sys/Cargo.toml
+++ b/rdkit-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdkit-sys"
 authors = ["Xavier Lange (xrlange@gmail.com)", "chrissly31415"]
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 license = "MIT"
 description = "RDKit CFFI library builder and bindings"


### PR DESCRIPTION
Bumping version from 0.4.7 to 0.4.8 prior to new release