### PR TITLE
Make ROMol Send

### DIFF
--- a/src/graphmol/ro_mol.rs
+++ b/src/graphmol/ro_mol.rs
@@ -9,6 +9,8 @@ pub struct ROMol {
     pub(crate) ptr: cxx::SharedPtr<ro_mol_ffi::ROMol>,
 }
 
+unsafe impl Send for ROMol {}
+
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum ROMolError {
     #[error("could not convert smiles to romol (nullptr)")]


### PR DESCRIPTION
We want to build a `lazy_static!` Vec in another project and need ROMol to be Send so it can be stuffed in an `Arc<Mutex<>>`