### PR TITLE
Refactored PeriodicTable

### DIFF
--- a/rdkit-sys/src/bridge/mod.rs
+++ b/rdkit-sys/src/bridge/mod.rs
@@ -11,7 +11,7 @@ mod mol_standardize;
 pub use mol_standardize::ffi as mol_standardize_ffi;
 
 mod periodic_table;
-pub use periodic_table::ffi as periodic_table_ffi;
+pub use periodic_table::{ffi as periodic_table_ffi, PeriodicTableOps};
 
 mod ro_mol;
 pub use ro_mol::ffi as ro_mol_ffi;

--- a/rdkit-sys/src/bridge/periodic_table.rs
+++ b/rdkit-sys/src/bridge/periodic_table.rs
@@ -1,8 +1,9 @@
 #[cxx::bridge(namespace = "RDKit")]
 pub mod ffi {
     unsafe extern "C++" {
+        type PeriodicTable;
         include!("wrapper/include/periodic_table.h");
         pub fn get_valence_list(atomic_number: u32) -> &'static CxxVector<i32>;
-        pub fn get_most_common_isotope_mass(atom: &CxxString) -> f64;
+        pub fn getMostCommonIsotopeMass(self: &PeriodicTable, atom: &CxxString) -> f64;
     }
 }

--- a/rdkit-sys/src/bridge/periodic_table.rs
+++ b/rdkit-sys/src/bridge/periodic_table.rs
@@ -3,6 +3,7 @@ pub mod ffi {
     unsafe extern "C++" {
         type PeriodicTable;
         include!("wrapper/include/periodic_table.h");
+        pub fn get_periodic_table() -> UniquePtr<PeriodicTable>;
         pub fn get_valence_list(atomic_number: u32) -> &'static CxxVector<i32>;
         pub fn getMostCommonIsotopeMass(self: &PeriodicTable, atom: &CxxString) -> f64;
     }

--- a/rdkit-sys/src/bridge/periodic_table.rs
+++ b/rdkit-sys/src/bridge/periodic_table.rs
@@ -1,10 +1,42 @@
+use cxx::{CxxVector, UniquePtr};
+use ffi::PeriodicTable;
+
 #[cxx::bridge(namespace = "RDKit")]
 pub mod ffi {
     unsafe extern "C++" {
         type PeriodicTable;
         include!("wrapper/include/periodic_table.h");
         pub fn get_periodic_table() -> UniquePtr<PeriodicTable>;
-        pub fn get_valence_list(atomic_number: u32) -> &'static CxxVector<i32>;
+        pub fn getAtomicWeight(self: &PeriodicTable, atomic_number: u32) -> f64;
+        pub fn getAtomicNumber(self: &PeriodicTable, atom: &CxxString) -> i32;
+        pub fn getElementSymbol(atomic_number: u32) -> String;
+        pub fn getElementName(atomic_number: u32) -> String;
+        pub fn getRvdw(self: &PeriodicTable, atomic_number: u32) -> f64;
+        pub fn getRcovalent(self: &PeriodicTable, atomic_number: u32) -> f64;
+        pub fn getRb0(self: &PeriodicTable, atomic_number: u32) -> f64;
+        pub fn getDefaultValence(self: &PeriodicTable, atomic_number: u32) -> i32;
+        fn getValenceList(atomic_number: u32) -> &'static CxxVector<i32>;
+        pub fn getNouterElecs(self: &PeriodicTable, atomic_number: u32) -> i32;
+        pub fn getMostCommonIsotope(self: &PeriodicTable, atomic_number: u32) -> i32;
         pub fn getMostCommonIsotopeMass(self: &PeriodicTable, atom: &CxxString) -> f64;
+    }
+}
+
+pub trait PeriodicTableOps {
+    fn getElementSymbol(self, atomic_number: u32) -> String;
+    fn getElementName(self, atomic_number: u32) -> String;
+    fn getValenceList(self, atomic_number: u32) -> &'static CxxVector<i32>;
+}
+impl<'a> PeriodicTableOps for UniquePtr<PeriodicTable> {
+    fn getElementSymbol(self, atomic_number: u32) -> String {
+        ffi::getElementSymbol(atomic_number)
+    }
+
+    fn getElementName(self, atomic_number: u32) -> String {
+        ffi::getElementName(atomic_number)
+    }
+
+    fn getValenceList(self, atomic_number: u32) -> &'static CxxVector<i32> {
+        ffi::getValenceList(atomic_number)
     }
 }

--- a/rdkit-sys/src/bridge/periodic_table.rs
+++ b/rdkit-sys/src/bridge/periodic_table.rs
@@ -1,3 +1,6 @@
+// allow camel case
+#![allow(non_snake_case)]
+
 use cxx::{CxxVector, UniquePtr};
 use ffi::PeriodicTable;
 
@@ -19,6 +22,19 @@ pub mod ffi {
         pub fn getNouterElecs(self: &PeriodicTable, atomic_number: u32) -> i32;
         pub fn getMostCommonIsotope(self: &PeriodicTable, atomic_number: u32) -> i32;
         pub fn getMostCommonIsotopeMass(self: &PeriodicTable, atom: &CxxString) -> f64;
+        pub fn getMassForIsotope(self: &PeriodicTable, atomic_number: u32, isotope: u32) -> f64;
+        pub fn getMaxAtomicNumber(self: &PeriodicTable) -> u32;
+        pub fn getAbundanceForIsotope(
+            self: &PeriodicTable,
+            atomic_number: u32,
+            isotope: u32,
+        ) -> f64;
+        pub fn moreElectroNegative(
+            self: &PeriodicTable,
+            atomic_number1: u32,
+            atomic_number2: u32,
+        ) -> bool;
+        pub fn getRow(self: &PeriodicTable, atomic_number: u32) -> u32;
     }
 }
 

--- a/rdkit-sys/tests/test_periodic_table.rs
+++ b/rdkit-sys/tests/test_periodic_table.rs
@@ -89,3 +89,38 @@ fn test_getMostCommonIsotope() {
     let isotope = periodic_table.getMostCommonIsotope(6);
     assert_eq!(isotope, 12);
 }
+
+#[test]
+fn test_getRow() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let row = periodic_table.getRow(6);
+    assert_eq!(row, 2);
+}
+
+#[test]
+fn test_getMassForIsotope() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let mass = periodic_table.getMassForIsotope(6, 13);
+    assert_eq!(mass, 13.00335484);
+}
+
+#[test]
+fn test_getMaxAtomicNumber() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let max = periodic_table.getMaxAtomicNumber();
+    assert_eq!(max, 118);
+}
+
+#[test]
+fn test_getAbundanceForIsotope() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let abundance = periodic_table.getAbundanceForIsotope(6, 13);
+    assert_eq!(abundance, 1.07);
+}
+
+#[test]
+fn test_moreElectroNegative() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let more_electro = periodic_table.moreElectroNegative(6, 7);
+    assert_eq!(more_electro, false);
+}

--- a/rdkit-sys/tests/test_periodic_table.rs
+++ b/rdkit-sys/tests/test_periodic_table.rs
@@ -1,9 +1,14 @@
+// ignore camel case
+#![allow(non_snake_case)]
+
 use cxx::let_cxx_string;
+use rdkit_sys::PeriodicTableOps;
 
 #[test]
 fn test_get_valence_list() {
-    let list = rdkit_sys::periodic_table_ffi::get_valence_list(1);
-    assert_eq!(list.as_slice(), &[1]);
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let list = periodic_table.getValenceList(6);
+    assert_eq!(list.as_slice(), &[4]);
 }
 
 #[test]
@@ -12,4 +17,75 @@ fn test_get_monoisotopic_mass() {
     let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
     let mass = periodic_table.getMostCommonIsotopeMass(&atom);
     assert_eq!(mass, 12.00);
+}
+
+#[test]
+fn test_getAtomicWeight() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let weight = periodic_table.getAtomicWeight(6);
+    assert_eq!(weight, 12.011);
+}
+
+#[test]
+fn test_getAtomicNumber() {
+    let_cxx_string!(atom = "C");
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let number = periodic_table.getAtomicNumber(&atom);
+    assert_eq!(number, 6);
+}
+
+#[test]
+fn test_getElementSymbol() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let symbol = periodic_table.getElementSymbol(6);
+    assert_eq!(symbol, "C");
+}
+
+#[test]
+fn test_getElementName() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let name = periodic_table.getElementName(6);
+    assert_eq!(name, "Carbon");
+}
+
+#[test]
+fn test_getRvdw() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let rvdw = periodic_table.getRvdw(6);
+    assert_eq!(rvdw, 1.7);
+}
+
+#[test]
+fn test_getRcovalent() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let rcovalent = periodic_table.getRcovalent(6);
+    assert_eq!(rcovalent, 0.76);
+}
+
+#[test]
+fn test_getRb0() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let rb0 = periodic_table.getRb0(6);
+    assert_eq!(rb0, 0.77);
+}
+
+#[test]
+fn test_getDefaultValence() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let valence = periodic_table.getDefaultValence(6);
+    assert_eq!(valence, 4);
+}
+
+#[test]
+fn test_getNouterElecs() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let nouter = periodic_table.getNouterElecs(6);
+    assert_eq!(nouter, 4);
+}
+
+#[test]
+fn test_getMostCommonIsotope() {
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let isotope = periodic_table.getMostCommonIsotope(6);
+    assert_eq!(isotope, 12);
 }

--- a/rdkit-sys/tests/test_periodic_table.rs
+++ b/rdkit-sys/tests/test_periodic_table.rs
@@ -9,6 +9,7 @@ fn test_get_valence_list() {
 #[test]
 fn test_get_monoisotopic_mass() {
     let_cxx_string!(atom = "C");
-    let mass = rdkit_sys::periodic_table_ffi::get_most_common_isotope_mass(&atom);
+    let periodic_table = rdkit_sys::periodic_table_ffi::get_periodic_table();
+    let mass = periodic_table.getMostCommonIsotopeMass(&atom);
     assert_eq!(mass, 12.00);
 }

--- a/rdkit-sys/wrapper/include/periodic_table.h
+++ b/rdkit-sys/wrapper/include/periodic_table.h
@@ -4,6 +4,7 @@
 #include <GraphMol/PeriodicTable.h>
 
 namespace RDKit {
+std::unique_ptr<PeriodicTable> get_periodic_table();
 const std::vector<int> &get_valence_list(unsigned int atomic_number);
 // double get_most_common_isotope_mass(const std::string &symbol);
 } // namespace RDKit

--- a/rdkit-sys/wrapper/include/periodic_table.h
+++ b/rdkit-sys/wrapper/include/periodic_table.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "rust/cxx.h"
+#include <GraphMol/PeriodicTable.h>
 
 namespace RDKit {
 const std::vector<int> &get_valence_list(unsigned int atomic_number);
-double get_most_common_isotope_mass(const std::string &symbol);
+// double get_most_common_isotope_mass(const std::string &symbol);
 } // namespace RDKit

--- a/rdkit-sys/wrapper/include/periodic_table.h
+++ b/rdkit-sys/wrapper/include/periodic_table.h
@@ -5,6 +5,7 @@
 
 namespace RDKit {
 std::unique_ptr<PeriodicTable> get_periodic_table();
-const std::vector<int> &get_valence_list(unsigned int atomic_number);
-// double get_most_common_isotope_mass(const std::string &symbol);
+rust::String getElementSymbol(unsigned int atomic_number);
+rust::String getElementName(unsigned int atomic_number);
+const std::vector<int> &getValenceList(unsigned int atomic_number);
 } // namespace RDKit

--- a/rdkit-sys/wrapper/src/periodic_table.cc
+++ b/rdkit-sys/wrapper/src/periodic_table.cc
@@ -2,6 +2,13 @@
 #include <rdkit/GraphMol/PeriodicTable.h>
 
 namespace RDKit {
+std::unique_ptr<PeriodicTable> get_periodic_table() {
+	// in rdkit we have the following:
+	// PeriodicTable::getTable() return : const PeriodicTable*
+	// so we need to take into account that it is a const pointer
+	return std::make_unique<PeriodicTable>(*PeriodicTable::getTable());
+}
+
 const std::vector<int> &get_valence_list(unsigned int atomic_number) {
 	PeriodicTable *pt = RDKit::PeriodicTable::getTable();
 	return pt->getValenceList(atomic_number);

--- a/rdkit-sys/wrapper/src/periodic_table.cc
+++ b/rdkit-sys/wrapper/src/periodic_table.cc
@@ -7,8 +7,8 @@ const std::vector<int> &get_valence_list(unsigned int atomic_number) {
 	return pt->getValenceList(atomic_number);
 }
 
-double get_most_common_isotope_mass(const std::string &symbol) {
-	PeriodicTable *pt = RDKit::PeriodicTable::getTable();
-	return pt->getMostCommonIsotopeMass(symbol);
-}
+// double get_most_common_isotope_mass(const std::string &symbol) {
+// PeriodicTable *pt = RDKit::PeriodicTable::getTable();
+// return pt->getMostCommonIsotopeMass(symbol);
+// }
 } // namespace RDKit

--- a/rdkit-sys/wrapper/src/periodic_table.cc
+++ b/rdkit-sys/wrapper/src/periodic_table.cc
@@ -8,14 +8,19 @@ std::unique_ptr<PeriodicTable> get_periodic_table() {
 	// so we need to take into account that it is a const pointer
 	return std::make_unique<PeriodicTable>(*PeriodicTable::getTable());
 }
+rust::String getElementSymbol(unsigned int atomic_number) {
+	PeriodicTable *pt = RDKit::PeriodicTable::getTable();
+	return pt->getElementSymbol(atomic_number);
+}
 
-const std::vector<int> &get_valence_list(unsigned int atomic_number) {
+rust::String getElementName(unsigned int atomic_number) {
+	PeriodicTable *pt = RDKit::PeriodicTable::getTable();
+	return pt->getElementName(atomic_number);
+}
+
+const std::vector<int> &getValenceList(unsigned int atomic_number) {
 	PeriodicTable *pt = RDKit::PeriodicTable::getTable();
 	return pt->getValenceList(atomic_number);
 }
 
-// double get_most_common_isotope_mass(const std::string &symbol) {
-// PeriodicTable *pt = RDKit::PeriodicTable::getTable();
-// return pt->getMostCommonIsotopeMass(symbol);
-// }
 } // namespace RDKit

--- a/src/periodic_table.rs
+++ b/src/periodic_table.rs
@@ -1,14 +1,16 @@
 use cxx::{let_cxx_string, CxxVector};
+use rdkit_sys::PeriodicTableOps;
 
 pub struct PeriodicTable {}
 
 impl PeriodicTable {
     pub fn get_valence_list(atomic_number: u32) -> &'static CxxVector<i32> {
-        rdkit_sys::periodic_table_ffi::get_valence_list(atomic_number)
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getValenceList(atomic_number)
     }
 
     pub fn get_most_common_isotope_mass(atom: &str) -> f64 {
         let_cxx_string!(atom_cxx_string = atom);
-        rdkit_sys::periodic_table_ffi::get_most_common_isotope_mass(&atom_cxx_string)
+        rdkit_sys::periodic_table_ffi::get_periodic_table()
+            .getMostCommonIsotopeMass(&atom_cxx_string)
     }
 }

--- a/src/periodic_table.rs
+++ b/src/periodic_table.rs
@@ -93,7 +93,7 @@ impl PeriodicTable {
 
     /// Returns the mass of the isotope
     /// # Arguments
-    /// * `atomic_number` - The atomic number of the element    
+    /// * `atomic_number` - The atomic number of the element
     /// * `isotope` - The isotope number
     pub fn get_mass_for_isotope(atomic_number: u32, isotope: u32) -> f64 {
         rdkit_sys::periodic_table_ffi::get_periodic_table()

--- a/src/periodic_table.rs
+++ b/src/periodic_table.rs
@@ -90,4 +90,43 @@ impl PeriodicTable {
     pub fn get_most_common_isotope(atomic_number: u32) -> i32 {
         rdkit_sys::periodic_table_ffi::get_periodic_table().getMostCommonIsotope(atomic_number)
     }
+
+    /// Returns the mass of the isotope
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element    
+    /// * `isotope` - The isotope number
+    pub fn get_mass_for_isotope(atomic_number: u32, isotope: u32) -> f64 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table()
+            .getMassForIsotope(atomic_number, isotope)
+    }
+
+    /// Returns the maximum recognized atomic number
+    pub fn get_max_atomic_number() -> u32 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getMaxAtomicNumber()
+    }
+
+    /// Returns the abundance of the isotope
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    /// * `isotope` - The isotope number
+    pub fn get_abundance_for_isotope(atomic_number: u32, isotope: u32) -> f64 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table()
+            .getAbundanceForIsotope(atomic_number, isotope)
+    }
+
+    /// Returns true if the first atom is more electronegative than the second
+    /// # Arguments
+    /// * `atomic_number1` - The atomic number of the first element
+    /// * `atomic_number2` - The atomic number of the second element
+    pub fn more_electro_negative(atomic_number1: u32, atomic_number2: u32) -> bool {
+        rdkit_sys::periodic_table_ffi::get_periodic_table()
+            .moreElectroNegative(atomic_number1, atomic_number2)
+    }
+
+    /// Returns the row of the periodic table
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_row(atomic_number: u32) -> u32 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getRow(atomic_number)
+    }
 }

--- a/src/periodic_table.rs
+++ b/src/periodic_table.rs
@@ -4,13 +4,90 @@ use rdkit_sys::PeriodicTableOps;
 pub struct PeriodicTable {}
 
 impl PeriodicTable {
+    /// Returns a vector of all stable valences. For atoms where we really don't
+    /// have any idea what a reasonable maximum valence is (like transition
+    /// metals), the vector ends with -1
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
     pub fn get_valence_list(atomic_number: u32) -> &'static CxxVector<i32> {
         rdkit_sys::periodic_table_ffi::get_periodic_table().getValenceList(atomic_number)
     }
 
+    /// Returns the mass of the most common isotope
+    /// # Arguments
+    /// * `atom` - The symbol of the element
     pub fn get_most_common_isotope_mass(atom: &str) -> f64 {
         let_cxx_string!(atom_cxx_string = atom);
         rdkit_sys::periodic_table_ffi::get_periodic_table()
             .getMostCommonIsotopeMass(&atom_cxx_string)
+    }
+
+    /// Returns the atomic weight of the atom
+    pub fn get_atomic_weight(atomic_number: u32) -> f64 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getAtomicWeight(atomic_number)
+    }
+
+    /// Returns the atomic number of the atom
+    /// # Arguments
+    /// * `atom` - The symbol of the element
+    pub fn get_atomic_number(atom: &str) -> i32 {
+        let_cxx_string!(atom_cxx_string = atom);
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getAtomicNumber(&atom_cxx_string)
+    }
+
+    /// Returns the symbol of the element
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_element_symbol(atomic_number: u32) -> String {
+        rdkit_sys::periodic_table_ffi::getElementSymbol(atomic_number)
+    }
+
+    /// Returns the full element name
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_element_name(atomic_number: u32) -> String {
+        rdkit_sys::periodic_table_ffi::getElementName(atomic_number)
+    }
+
+    /// Returns the atom's Van der Waals radius
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_radius_van_der_waals(atomic_number: u32) -> f64 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getRvdw(atomic_number)
+    }
+
+    /// Returns the atom's covalent radius
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_radius_covalent(atomic_number: u32) -> f64 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getRcovalent(atomic_number)
+    }
+
+    /// Returns the atom's bond radius
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_radius_b0(atomic_number: u32) -> f64 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getRb0(atomic_number)
+    }
+
+    /// Returns the atom's default valence
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_default_valence(atomic_number: u32) -> i32 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getDefaultValence(atomic_number)
+    }
+
+    /// Returns the number of outer shell electrons
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_n_outer_elecs(atomic_number: u32) -> i32 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getNouterElecs(atomic_number)
+    }
+
+    /// Returns the atom's most common isotope
+    /// # Arguments
+    /// * `atomic_number` - The atomic number of the element
+    pub fn get_most_common_isotope(atomic_number: u32) -> i32 {
+        rdkit_sys::periodic_table_ffi::get_periodic_table().getMostCommonIsotope(atomic_number)
     }
 }

--- a/tests/test_periodic_table.rs
+++ b/tests/test_periodic_table.rs
@@ -3,7 +3,7 @@ use rdkit::PeriodicTable;
 #[test]
 fn test_valence_list() {
     let valence_list = PeriodicTable::get_valence_list(6);
-    assert_eq!(&valence_list.iter().cloned().collect::<Vec<_>>(), &[4]);
+    assert_eq!(valence_list.as_slice(), &[4]);
 }
 
 #[test]

--- a/tests/test_periodic_table.rs
+++ b/tests/test_periodic_table.rs
@@ -11,3 +11,57 @@ fn test_most_common_isotope_mass() {
     let mass = PeriodicTable::get_most_common_isotope_mass("C");
     assert_eq!(mass, 12.00);
 }
+
+#[test]
+fn test_atomic_weight() {
+    let weight = PeriodicTable::get_atomic_weight(6);
+    assert_eq!(weight, 12.011);
+}
+
+#[test]
+fn test_atomic_number() {
+    let number = PeriodicTable::get_atomic_number("C");
+    assert_eq!(number, 6);
+}
+
+#[test]
+fn test_element_symbol() {
+    let symbol = PeriodicTable::get_element_symbol(6);
+    assert_eq!(symbol, "C");
+}
+
+#[test]
+fn test_element_name() {
+    let name = PeriodicTable::get_element_name(6);
+    assert_eq!(name, "Carbon");
+}
+
+#[test]
+fn test_radius_van_der_waals() {
+    let radius = PeriodicTable::get_radius_van_der_waals(6);
+    assert_eq!(radius, 1.7);
+}
+
+#[test]
+fn test_radius_covalent() {
+    let radius = PeriodicTable::get_radius_covalent(6);
+    assert_eq!(radius, 0.76);
+}
+
+#[test]
+fn test_radius_bond() {
+    let radius = PeriodicTable::get_radius_b0(6);
+    assert_eq!(radius, 0.77);
+}
+
+#[test]
+fn test_default_valence() {
+    let valence = PeriodicTable::get_default_valence(6);
+    assert_eq!(valence, 4);
+}
+
+#[test]
+fn test_outer_electrons() {
+    let electrons = PeriodicTable::get_n_outer_elecs(6);
+    assert_eq!(electrons, 4);
+}

--- a/tests/test_periodic_table.rs
+++ b/tests/test_periodic_table.rs
@@ -65,3 +65,39 @@ fn test_outer_electrons() {
     let electrons = PeriodicTable::get_n_outer_elecs(6);
     assert_eq!(electrons, 4);
 }
+
+#[test]
+fn test_most_common_isotope() {
+    let isotope = PeriodicTable::get_most_common_isotope(6);
+    assert_eq!(isotope, 12);
+}
+
+#[test]
+fn test_get_row() {
+    let row = PeriodicTable::get_row(6);
+    assert_eq!(row, 2);
+}
+
+#[test]
+fn test_mass_for_isotope() {
+    let mass = PeriodicTable::get_mass_for_isotope(6, 13);
+    assert_eq!(mass, 13.00335484);
+}
+
+#[test]
+fn test_get_max_atomic_number() {
+    let max = PeriodicTable::get_max_atomic_number();
+    assert_eq!(max, 118);
+}
+
+#[test]
+fn get_abundance_for_isotope() {
+    let abundance = PeriodicTable::get_abundance_for_isotope(6, 12);
+    assert_eq!(abundance, 98.93);
+}
+
+#[test]
+fn more_electro_negative() {
+    let more_electro = PeriodicTable::more_electro_negative(6, 7);
+    assert_eq!(more_electro, false);
+}


### PR DESCRIPTION
Solves #39. 

As you can see, there is no need to write the C++ function anymore. This still compiles. We would then need to write in the wrapper the constructors for our different objects and the function that cause problems in the conversion. 